### PR TITLE
fix K1 container image version

### DIFF
--- a/.containers/K1/docker/Dockerfile
+++ b/.containers/K1/docker/Dockerfile
@@ -24,7 +24,7 @@
 # one of the top performing teams: Team Tusk
 ###############################################################################
 
-FROM ubuntu
+FROM ubuntu:19.10
 LABEL maintainer="Mattia Tomasoni <mattia.tomasoni@unil.ch>"
 
 ###############################################################################

--- a/.containers/K1/singularity/Singularity
+++ b/.containers/K1/singularity/Singularity
@@ -25,7 +25,7 @@
 ###############################################################################
 
 Bootstrap: docker
-From: ubuntu
+From: ubuntu:19.10
 
 %labels
 AUTHOR Mattia Tomasoni <mattia.tomasoni@unil.ch>


### PR DESCRIPTION
The problem is that the K1 container is built from the latest ubuntu, and 20.04 was just recently released, which became the latest. In the latest image the "RUN apt-get -y install python-igraph" and the "RUN apt install -y python-pip && pip install --upgrade pip" commands break the container building. I think the easiest fix is to fix the image version to "ubuntu:19.10". It worked for me, and with fixing the version similar problems in the future can be avoided.