### PR TITLE
K1: specify igraph version for Python 2 compatibility

### DIFF
--- a/.containers/K1/docker/Dockerfile
+++ b/.containers/K1/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN apt -y install curl
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 RUN python2 get-pip.py
 
-RUN pip2 install python-igraph
+RUN pip2 install python-igraph==0.8.3
 RUN pip2 install scikit-learn
 RUN pip2 install numpy scipy
 RUN pip2 install argparse

--- a/.containers/K1/singularity/Singularity
+++ b/.containers/K1/singularity/Singularity
@@ -40,7 +40,7 @@ apt update && \
   apt -y install curl && \
   curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
   python2 get-pip.py && \
-  pip2 install python-igraph && \
+  pip2 install python-igraph==0.8.3 && \
   pip2 install scikit-learn && \
   pip2 install numpy scipy && \
   pip2 install argparse && \


### PR DESCRIPTION
Closes #47.

Newer versions of `igraph` aren't compatible with Python 2.7 which the K1 method uses, so we need to explicitly specify an older version that is compatible.